### PR TITLE
see description on PR

### DIFF
--- a/safespace-backend/requirements.txt
+++ b/safespace-backend/requirements.txt
@@ -16,7 +16,6 @@ cryptography==44.0.2
 curl_cffi==0.10.0
 cycler==0.12.1
 Deprecated==1.2.18
-dotenv==0.9.9
 firebase-admin==6.7.0
 Flask==3.1.0
 Flask-Caching==2.3.1
@@ -45,6 +44,7 @@ googleapis-common-protos==1.70.0
 greenlet==3.1.1
 grpcio==1.71.0
 grpcio-status==1.71.0
+gunicorn==23.0.0
 httplib2==0.22.0
 idna==3.10
 iniconfig==2.1.0
@@ -55,7 +55,6 @@ jsonschema-specifications==2025.4.1
 jws==0.1.3
 kiwisolver==1.4.8
 limits==4.7.3
-lxml==5.4.0
 Mako==1.3.10
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2


### PR DESCRIPTION
I installed Gunicorn and added it to the list of dependencies.
I removed dotenv from the list of dependencies.
I added code to the conf file to tell Nginx to accept the CORS access headers. 
I think we are ready to redeploy backend and test again.